### PR TITLE
Bugfix/styles

### DIFF
--- a/src/components/ContactCard/ContactCardStyled.ts
+++ b/src/components/ContactCard/ContactCardStyled.ts
@@ -29,6 +29,7 @@ const ContactCardStyled = styled.article`
     }
 
     &__delete-button {
+      color: ${(props) => props.theme.colors.gray950};
       padding: 0;
       height: 48px;
       width: 48px;

--- a/src/components/ContactForm/ContactFormStyled.ts
+++ b/src/components/ContactForm/ContactFormStyled.ts
@@ -32,6 +32,10 @@ const ContactFormStyled = styled.form`
         &::placeholder {
           color: ${(props) => props.theme.colors.gray700};
         }
+
+        &[type="date"] {
+          color: ${(props) => props.theme.colors.gray700};
+        }
       }
 
       &-icon {

--- a/src/components/ContactForm/ContactFormStyled.ts
+++ b/src/components/ContactForm/ContactFormStyled.ts
@@ -10,6 +10,11 @@ const ContactFormStyled = styled.form`
   .input-wrapper {
     display: flex;
     width: 100%;
+
+    &:focus-within {
+      outline: 2px solid ${(props) => props.theme.colors.primary600};
+      border-radius: ${(props) => props.theme.radius.normal};
+    }
   }
 
   .contact-form {
@@ -34,7 +39,20 @@ const ContactFormStyled = styled.form`
         }
 
         &[type="date"] {
+          position: relative;
+          text-align: left;
           color: ${(props) => props.theme.colors.gray700};
+        }
+
+        &[type="date"]::-webkit-calendar-picker-indicator {
+          position: absolute;
+          top: 0;
+          right: 0;
+          width: 100%;
+          height: 100%;
+          padding: 0;
+          color: transparent;
+          background: transparent;
         }
       }
 

--- a/src/components/ContactList/ContactList.tsx
+++ b/src/components/ContactList/ContactList.tsx
@@ -37,7 +37,9 @@ const ContactList = ({ contacts }: ContactListProps): React.ReactElement => {
             <ContactCard contact={contact} onDeleteClick={handleDeleteClick} />
           </li>
         ))}
-      <LoadMore handleButtonClick={handleLoadMoreClick} />
+      {contacts.length >= 10 && (
+        <LoadMore handleButtonClick={handleLoadMoreClick} />
+      )}
     </ContactListStyled>
   );
 };


### PR DESCRIPTION
- Added color reset for iOS, the date input was appearing blue on iphones
- Show Load more button only if user has more than 10 contacts
- Added brand color outline for when the user has focus on inputs of the Contact Form
- Remove the date picker default icon and made input width 100% so the area is clickable all around 